### PR TITLE
feat: add department filter to employees table

### DIFF
--- a/src/features/employees/presentation/pages/EmployeesPage.tsx
+++ b/src/features/employees/presentation/pages/EmployeesPage.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
-import { useGetEmployeesQuery } from "../../data/employeesApi";
+import { useGetEmployeesQuery, useGetDepartmentsQuery } from "../../data/employeesApi";
 import { EmployeesTable } from "../components/EmployeesTable";
 import { EmployeeCreateForm } from "../components/EmployeeCreateForm";
 
 export function EmployeesPage() {
   const [showCreateForm, setShowCreateForm] = useState(false);
+  const [selectedDepartment, setSelectedDepartment] = useState("");
   const { data: employees = [], isLoading, isError } = useGetEmployeesQuery();
+  const { data: departments = [] } = useGetDepartmentsQuery();
 
   if (isLoading) {
     return <p className="p-8 text-gray-500">Loading employees...</p>;
@@ -14,6 +16,10 @@ export function EmployeesPage() {
   if (isError) {
     return <p className="p-8 text-red-600">Failed to load employees.</p>;
   }
+
+  const filteredEmployees = selectedDepartment
+    ? employees.filter((e) => e.department === selectedDepartment)
+    : employees;
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
@@ -43,7 +49,23 @@ export function EmployeesPage() {
         </div>
       )}
 
-      <EmployeesTable employees={employees} />
+      <div className="mb-4">
+        <select
+          value={selectedDepartment}
+          onChange={(e) => setSelectedDepartment(e.target.value)}
+          className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          aria-label="Filter by department"
+        >
+          <option value="">All Departments</option>
+          {departments.map((dept) => (
+            <option key={dept.id} value={dept.name}>
+              {dept.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <EmployeesTable employees={filteredEmployees} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #1

- Added a department filter dropdown above the employees table using the existing `useGetDepartmentsQuery` hook
- Filters employees client-side in real-time when a department is selected
- Defaults to "All Departments" showing every employee

## Test plan

- [ ] Start mock API (`npm run mock`) and dev server (`npm run dev`)
- [ ] Verify dropdown shows "All Departments" + all departments from `/departments`
- [ ] Select a department and confirm table shows only matching employees
- [ ] Select "All Departments" and confirm all employees are shown again
- [ ] Verify the dropdown is accessible via keyboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)