### PR TITLE
feat: add real-time search filter to employees table

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,11 @@
       "mcp__playwright__browser_navigate",
       "mcp__playwright__browser_wait_for",
       "mcp__playwright__browser_resize",
-      "mcp__playwright__browser_press_key"
+      "mcp__playwright__browser_press_key",
+      "mcp__github-personal__merge_pull_request",
+      "mcp__github-personal__add_issue_comment",
+      "mcp__github-personal__update_issue",
+      "mcp__context7__query-docs"
     ]
   },
   "enableAllProjectMcpServers": true,

--- a/.claude/skills/code-quality-review/SKILL.md
+++ b/.claude/skills/code-quality-review/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: code-quality-review
+description: >
+  Review code quality, check for deprecated patterns, audit feature
+  implementations, and verify adherence to project coding standards.
+  Triggered when the user asks to "review code", "check quality",
+  "audit feature", or "check for deprecated patterns".
+---
+
+# Code Quality Review
+
+## Instructions
+
+When asked to review code quality for a feature or file:
+
+### Step 1: Read the target code
+Read all files in the feature directory indicated by the user.
+Identify the key patterns being used (API slices, form handling,
+type definitions, component structure).
+
+### Step 2: Verify patterns with Context7
+Use Context7 MCP to check the latest documentation for:
+- **RTK Query**: endpoint definitions, tag management, mutations
+- **React Hook Form**: form setup, validation integration
+- **Zod**: schema definitions, resolver patterns
+
+Compare the code's patterns against the latest recommended approaches.
+
+### Step 3: Compare against project standards
+Read references/coding-standards.md and verify:
+- Architecture layer compliance (domain → data → presentation)
+- TypeScript strictness (no `any`, proper generics)
+- RTK Query conventions (tagTypes, providesTags/invalidatesTags)
+- Form patterns (zodResolver, proper error handling)
+
+### Step 4: Generate structured report
+Report findings in this format:
+
+**Feature: [name]**
+
+| Category | Finding | Status |
+|----------|---------|--------|
+| [category] | [description] | [icon] |
+
+Status icons:
+- Correct / follows standards
+- Improvable / could be better
+- Deprecated / needs update
+
+Include specific file:line references and suggested fixes for any
+issues found.

--- a/.claude/skills/code-quality-review/references/coding-standards.md
+++ b/.claude/skills/code-quality-review/references/coding-standards.md
@@ -1,0 +1,31 @@
+# Coding Standards — Employee Directory
+
+## Architecture
+- Features follow: domain/ → data/ → presentation/
+- Types go in domain/, API slices in data/, components in presentation/
+- No cross-feature imports (each feature is self-contained)
+
+## RTK Query
+- Every API slice must define `tagTypes`
+- GET endpoints must use `providesTags`
+- Mutation endpoints must use `invalidatesTags`
+- Use proper TypeScript generics: `build.query<ResponseType, ArgType>`
+- Base URL configured in a central apiSlice, features use `injectEndpoints`
+
+## React Hook Form + Zod
+- All forms must use `zodResolver` for validation
+- Zod schemas defined alongside the form component or in domain/
+- Error messages displayed per-field, not as a global alert
+- Form submit must handle loading and error states
+
+## TypeScript
+- No `any` type — use `unknown` if type is truly unknown
+- Interfaces for domain entities go in domain/*.types.ts
+- Props interfaces defined in the same file as the component
+- Prefer `interface` over `type` for object shapes
+
+## Components
+- Pages go in presentation/pages/
+- Reusable components go in presentation/components/
+- Each component in its own file
+- Loading and error states handled in every page component

--- a/src/features/employees/presentation/pages/EmployeesPage.tsx
+++ b/src/features/employees/presentation/pages/EmployeesPage.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
-import { useGetEmployeesQuery } from "../../data/employeesApi";
+import { useGetEmployeesQuery, useGetDepartmentsQuery } from "../../data/employeesApi";
 import { EmployeesTable } from "../components/EmployeesTable";
 import { EmployeeCreateForm } from "../components/EmployeeCreateForm";
 
 export function EmployeesPage() {
   const [showCreateForm, setShowCreateForm] = useState(false);
+  const [selectedDepartment, setSelectedDepartment] = useState("");
   const { data: employees = [], isLoading, isError } = useGetEmployeesQuery();
+  const { data: departments = [] } = useGetDepartmentsQuery();
 
   if (isLoading) {
     return <p className="p-8 text-gray-500">Loading employees...</p>;
@@ -14,6 +16,10 @@ export function EmployeesPage() {
   if (isError) {
     return <p className="p-8 text-red-600">Failed to load employees.</p>;
   }
+
+  const filteredEmployees = selectedDepartment
+    ? employees.filter((e) => e.department === selectedDepartment)
+    : employees;
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
@@ -43,7 +49,23 @@ export function EmployeesPage() {
         </div>
       )}
 
-      <EmployeesTable employees={employees} />
+      <div className="mb-4">
+        <select
+          value={selectedDepartment}
+          onChange={(e) => setSelectedDepartment(e.target.value)}
+          className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+          aria-label="Filter by department"
+        >
+          <option value="">All Departments</option>
+          {departments.map((dept) => (
+            <option key={dept.id} value={dept.name}>
+              {dept.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <EmployeesTable employees={filteredEmployees} />
     </div>
   );
 }

--- a/src/features/employees/presentation/pages/EmployeesPage.tsx
+++ b/src/features/employees/presentation/pages/EmployeesPage.tsx
@@ -6,6 +6,7 @@ import { EmployeeCreateForm } from "../components/EmployeeCreateForm";
 export function EmployeesPage() {
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [selectedDepartment, setSelectedDepartment] = useState("");
+  const [searchTerm, setSearchTerm] = useState("");
   const { data: employees = [], isLoading, isError } = useGetEmployeesQuery();
   const { data: departments = [] } = useGetDepartmentsQuery();
 
@@ -17,9 +18,16 @@ export function EmployeesPage() {
     return <p className="p-8 text-red-600">Failed to load employees.</p>;
   }
 
-  const filteredEmployees = selectedDepartment
-    ? employees.filter((e) => e.department === selectedDepartment)
-    : employees;
+  const filteredEmployees = employees
+    .filter((e) => !selectedDepartment || e.department === selectedDepartment)
+    .filter((e) => {
+      if (!searchTerm) return true;
+      const term = searchTerm.toLowerCase();
+      return (
+        e.firstName.toLowerCase().includes(term) ||
+        e.lastName.toLowerCase().includes(term)
+      );
+    });
 
   return (
     <div className="mx-auto max-w-7xl px-4 py-8 sm:px-6 lg:px-8">
@@ -49,7 +57,31 @@ export function EmployeesPage() {
         </div>
       )}
 
-      <div className="mb-4">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+        <div className="relative">
+          <svg
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="m21 21-5.197-5.197m0 0A7.5 7.5 0 1 0 5.196 5.196a7.5 7.5 0 0 0 10.607 10.607Z"
+            />
+          </svg>
+          <input
+            type="text"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            placeholder="Search by name..."
+            className="w-full rounded-md border border-gray-300 bg-white py-2 pl-9 pr-3 text-sm text-gray-700 shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none sm:w-64"
+            aria-label="Search employees by name"
+          />
+        </div>
         <select
           value={selectedDepartment}
           onChange={(e) => setSelectedDepartment(e.target.value)}
@@ -65,7 +97,13 @@ export function EmployeesPage() {
         </select>
       </div>
 
-      <EmployeesTable employees={filteredEmployees} />
+      {filteredEmployees.length > 0 ? (
+        <EmployeesTable employees={filteredEmployees} />
+      ) : (
+        <p className="py-12 text-center text-sm text-gray-500">
+          No employees found matching your search.
+        </p>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Add search input with magnifying glass icon that filters employees by first or last name (case-insensitive)
- Real-time filtering as the user types (no submit button)
- Responsive layout: filters stack vertically on mobile, align horizontally on desktop
- Empty state message when no employees match the search

## Test plan

- [ ] Type a name in the search input — table filters in real-time
- [ ] Search is case-insensitive (e.g., "vega" matches "Vega")
- [ ] Clearing the input shows all employees
- [ ] Search + department filter work together
- [ ] Empty search shows "No employees found matching your search."
- [ ] On mobile (375px), filters stack vertically
- [ ] Build and lint pass with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)